### PR TITLE
Fix #136 remove html escape from the text widget

### DIFF
--- a/arc/js/entries/text.js
+++ b/arc/js/entries/text.js
@@ -29,7 +29,7 @@ TextEntry.prototype.Render = function(with_value){
             'data-entry-type="' + this.type + '" ' +
             'class="div-editable" ' + 
             'id="' + this.id + '" ' +
-            'contenteditable="true">'+this.safeValue()+"</div>"
+            'contenteditable="true">'+this.value+"</div>"
     );
 }
 


### PR DESCRIPTION
Issue #126 incorrectly stated that the text widget was susceptible to HTML injection,
re-testing on version v1.1.9 confirmed it to not be the case. 

Saving/Re-saving HTML escaped content of the editable div caused further deterioration of the input as it gets re-escaped again and stored modified.